### PR TITLE
Restart on change 2.6 updates

### DIFF
--- a/lib/moonshine/redis.rb
+++ b/lib/moonshine/redis.rb
@@ -1,6 +1,14 @@
 module Moonshine
   module Redis
     
+    def redis_config_boolean(key,default = true)
+      if key.nil?
+        default ? 'yes' : 'no'
+      else
+        ((!!key) == true) ? 'yes' : 'no'
+      end
+    end
+
     # Used in the recipe to decide whether or not to restart redis after config changes.
     def redis_restart_on_change
       restart_on_change = configuration[:redis][:restart_on_change]
@@ -23,7 +31,7 @@ module Moonshine
       version = options[:version] || '2.4.17'
 
       notifies = if redis_restart_on_change
-                   [service('redis')]
+                   [service('redis-server')]
                  else
                    []
                  end

--- a/templates/redis.conf.erb
+++ b/templates/redis.conf.erb
@@ -151,7 +151,7 @@ maxclients <%= options[:maxclients] || '0' %>
 # IMPORTANT: Check the BGREWRITEAOF to check how to rewrite the append
 # log file in background when it gets too big.
 
-appendonly <%= options[:appendonly] || 'no' %>
+appendonly <%= redis_config_boolean(options[:appendonly],false) %>
 
 # The fsync() call tells the Operating System to actually write data on disk
 # instead to wait for more data in the output buffer. Some OS will really flush 


### PR DESCRIPTION
Adds:
- Restart on change - defaults to true, but if set to false, it won't restart after config file change.
- Default version now 2.4.17
- Removes virtual memory settings if running a version > 2.4 since they've been removed and will cause errors.
